### PR TITLE
use bigger buttons for videoswitcher

### DIFF
--- a/components/VideoSwitcher.vue
+++ b/components/VideoSwitcher.vue
@@ -13,9 +13,8 @@
       livestreamUrl="https://stream.privacyweek.at/hls/orig/main_hd.m3u8"
     />
     <div class="video-track-selection mt-5">
-      <div class="is-size-7 ml-5">{{ $t('videoPlayer.selectTrack') }}</div>
       <button
-        class="button is-light is-rounded is-medium"
+        class="button ml-5 is-light is-rounded is-medium"
         :class="selectedTrack === 'original' ? 'active' : 'not-active'"
         @click="switchTrack('original')"
       >

--- a/components/VideoSwitcher.vue
+++ b/components/VideoSwitcher.vue
@@ -12,17 +12,17 @@
       v-else
       livestreamUrl="https://stream.privacyweek.at/hls/orig/main_hd.m3u8"
     />
-    <div class="video-track-selection">
+    <div class="video-track-selection mt-5">
       <div class="is-size-7 ml-5">{{ $t('videoPlayer.selectTrack') }}</div>
       <button
-        class="button is-text is-size-7"
+        class="button is-light is-rounded is-medium"
         :class="selectedTrack === 'original' ? 'active' : 'not-active'"
         @click="switchTrack('original')"
       >
         {{ $t('videoPlayer.original') }}
       </button>
       <button
-        class="button is-text is-size-7"
+        class="button is-light is-rounded is-medium"
         :class="selectedTrack === 'translation' ? 'active' : 'not-active'"
         @click="switchTrack('translation')"
       >


### PR DESCRIPTION
On request of @oe1rfc and the translation team we now use bigger buttons for the switch of original or translated video